### PR TITLE
fixes #6 - needed instructions for building the codelab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # demo-patient-lists
-
 A demonstration app and codelab companion to interactively teach developers how to use the FHIR Patient Lists API.
 
 # Codelab
-
 The codelab is hosted on GitHub pages at: <https://microsoft-healthcare-madison.github.io/demo-patient-lists>
+
+## Running Locally
+The codelab is built and tested locally in OSX (although it should work in windows, too) by running `npm run codelab`.  This requires that you already have the [claat](https://github.com/googlecodelabs/tools/tree/master/claat) and [kqwait](https://github.com/sschober/kqwait) tools installed.


### PR DESCRIPTION
Added instructions for building the codelab from source markdown.